### PR TITLE
アジェンダの削除機能実装

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,6 @@
 class AgendasController < ApplicationController
   # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,9 +16,19 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
+    end
+  end
+
+  def destroy
+    if current_user.id == @agenda.user_id || current_user.id == @agenda.team.owner_id
+      @agenda.destroy
+      DeletedAgendaMailer.deleted_agenda_mail(@agenda).deliver
+      redirect_to dashboard_path, notice: I18n.t('views.messages.delete_agenda')
+    else
+      redirect_to dashboard_path
     end
   end
 

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -14,15 +14,13 @@ class AssignsController < ApplicationController
 
   def destroy
     assign = Assign.find(params[:id])
-    # team = Team.find(assign.team_id)
-    # binding.irb
-    # if current_user.id != assign.user_id || current_user.id != team.owner_id
-    #   redirect_to root_path
-    # end
+    if current_user.id == assign.user_id || current_user.id == assign.team.owner_id
+      destroy_message = assign_destroy(assign, assign.user)
 
-    destroy_message = assign_destroy(assign, assign.user)
-
-    redirect_to team_url(params[:team_id]), notice: destroy_message
+      redirect_to team_url(params[:team_id]), notice: destroy_message
+    else
+      redirect_to team_url(params[:team_id])
+    end
   end
 
   private

--- a/app/mailers/deleted_agenda_mailer.rb
+++ b/app/mailers/deleted_agenda_mailer.rb
@@ -1,0 +1,7 @@
+class DeletedAgendaMailer < ApplicationMailer
+  def deleted_agenda_mail(agenda)
+    @agenda = agenda
+
+    mail to: @agenda.team.members.pluck(:email) ,subject: "agenda: #{@agenda.title}が削除されました"
+  end
+end

--- a/app/views/deleted_agenda_mailer/deleted_agenda_mail.html.erb
+++ b/app/views/deleted_agenda_mailer/deleted_agenda_mail.html.erb
@@ -1,0 +1,3 @@
+<h4>agenda:<%= @agenda.title %>が削除されました。</h4>
+<%= @agenda.team.name %>のアジェンダが削除されました。
+削除されたアジェンダ：<%= @agenda.title %>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,13 +30,18 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
-              <i class="fa fa-circle-o nav-icon"></i>
+            <span href="#" class="nav-link">
+              <%# <i class="fa fa-circle-o nav-icon"></i> %>
               <p>
+                <% if current_user.id == agenda.user_id || current_user.id == agenda.team.owner_id %>
+                  <%= link_to agenda_path(agenda.id), method: :delete, class: 'agenda-delete', data: { confirm: 'このアジェンダを削除してもよろしいですか？' } do %>
+                    <i class="fas fa-trash-alt"></i>
+                  <% end %>　
+                <% end %>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
               </p>
-            </a>
+            </span>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -237,6 +237,7 @@ ja:
       team_build2: 'チームを作成する'
       select_team: 'チーム選択'
       create_agenda: 'アジェンダ作成'
+      delete_agenda: 'アジェンダを削除しました'
       input_agenda_title: 'タイトル入力'
       input_team_name: 'チーム名を入力してください'
       recent_posts: '最近投稿された記事'

--- a/spec/mailers/deleted_agenda_spec.rb
+++ b/spec/mailers/deleted_agenda_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe DeletedAgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/deleted_agenda_preview.rb
+++ b/spec/mailers/previews/deleted_agenda_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/deleted_agenda
+class DeletedAgendaPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
issue#67の機能実装

```
現状サイドバーに表示される各アジェンダを削除する機能がないので、その機能を追加してほしい。

以下の要件で作成されることを想定している

AgendasControllerのdestroyアクションを追加し、そこに機能追加する
Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
Agendaに紐づいているarticleも一緒に削除される
Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
情報処理が完了した後はDashBoardに飛ぶ
その他、アプリケーションの挙動に不審な点やエラーがないこと
```